### PR TITLE
#23 terraform plan name changed from fmt so apply action will work

### DIFF
--- a/.github/workflows/plan.yaml
+++ b/.github/workflows/plan.yaml
@@ -1,4 +1,4 @@
-name: 'Terraform Plan/Format'
+name: 'Terraform Plan'
 
 on:
   pull_request:


### PR DESCRIPTION
As I referenced, Terraform Apply will run after the Terraform plan completes. If the file Terraform plan isn't named exactly, Apply won't recognise this and will not run.